### PR TITLE
Make stage2 work with Debian (`buster')

### DIFF
--- a/apt2ostree/apt.py
+++ b/apt2ostree/apt.py
@@ -274,7 +274,10 @@ dpkg_configure = Rule(
             sudo ln -s ../../../bin/true $$TARGET/usr/lib/insserv/insserv;
             sudo ln -s ../bin/true $$TARGET/sbin/insserv;
         fi;
-    	sudo ln -sf mawk "$$TARGET/usr/bin/awk";
+
+        if [ -f $$TARGET/usr/bin/mawk ]; then
+            sudo ln -sf mawk $$TARGET/usr/bin/awk;
+        fi;
 
         $$BWRAP dpkg --configure -a;
 

--- a/apt2ostree/apt.py
+++ b/apt2ostree/apt.py
@@ -255,8 +255,9 @@ dpkg_configure = Rule(
         mkdir -p $$tmpdir;
         TARGET=$$tmpdir/co;
         sudo ostree --repo=$ostree_repo checkout --force-copy $in_branch $$TARGET;
-        echo "root:x:0:0:root:/root:/bin/bash" | sudo sponge $$TARGET/etc/passwd;
-        echo "root:x:0:" | sudo sponge $$TARGET/etc/group;
+        sudo cp $$TARGET/usr/share/base-passwd/passwd.master $$TARGET/etc/passwd;
+        sudo cp $$TARGET/usr/share/base-passwd/group.master $$TARGET/etc/group;
+
         BWRAP="sudo bwrap --bind $$TARGET / --proc /proc --dev /dev
             --tmpfs /tmp --tmpfs /run --setenv LANG C.UTF-8
             --setenv DEBIAN_FRONTEND noninteractive

--- a/apt2ostree/apt.py
+++ b/apt2ostree/apt.py
@@ -262,8 +262,9 @@ dpkg_configure = Rule(
             --tmpfs /tmp --tmpfs /run --setenv LANG C.UTF-8
             --setenv DEBIAN_FRONTEND noninteractive
             $binfmt_misc_support";
-        $$BWRAP /var/lib/dpkg/info/dash.preinst install;
-
+        if [ -x $$TARGET/var/lib/dpkg/info/dash.preinst ]; then
+            $$BWRAP /var/lib/dpkg/info/dash.preinst install;
+        fi;
         printf '#!/bin/sh\\nexit 101'
         | sudo sponge $$tmpdir/co/usr/sbin/policy-rc.d;
         sudo chmod a+x $$tmpdir/co/usr/sbin/policy-rc.d;

--- a/apt2ostree/apt.py
+++ b/apt2ostree/apt.py
@@ -266,7 +266,7 @@ dpkg_configure = Rule(
             $$BWRAP /var/lib/dpkg/info/dash.preinst install;
         fi;
         printf '#!/bin/sh\\nexit 101'
-        | sudo sponge $$tmpdir/co/usr/sbin/policy-rc.d;
+        | sudo tee $$tmpdir/co/usr/sbin/policy-rc.d;
         sudo chmod a+x $$tmpdir/co/usr/sbin/policy-rc.d;
 
         if [ -f $$TARGET/usr/lib/insserv/insserv ]; then

--- a/apt2ostree/apt.py
+++ b/apt2ostree/apt.py
@@ -268,9 +268,11 @@ dpkg_configure = Rule(
         | sudo sponge $$tmpdir/co/usr/sbin/policy-rc.d;
         sudo chmod a+x $$tmpdir/co/usr/sbin/policy-rc.d;
 
-        $$BWRAP dpkg-divert --local --rename --add /usr/lib/insserv/insserv;
-        sudo ln -s ../../../bin/true $$TARGET/usr/lib/insserv/insserv;
-        sudo ln -s ../bin/true $$TARGET/sbin/insserv;
+        if [ -f $$TARGET/usr/lib/insserv/insserv ]; then
+            $$BWRAP dpkg-divert --local --rename --add /usr/lib/insserv/insserv;
+            sudo ln -s ../../../bin/true $$TARGET/usr/lib/insserv/insserv;
+            sudo ln -s ../bin/true $$TARGET/sbin/insserv;
+        fi;
     	sudo ln -sf mawk "$$TARGET/usr/bin/awk";
 
         $$BWRAP dpkg --configure -a;


### PR DESCRIPTION
The patchset is supposed to addresses the following problems in the stage2:

* `base-files' postinst fails due to missing groups
* symlinking 'awk' to 'mawk' breaks many packages' postinst scripts if the 'mawk' package is not installed
* failure if the 'moreutils' package is not installed in the host system

Note: this patchset is NOT enough for making debian images, there are two more problems which should be solved:

* Different APT URLs and components ('main contrib non-free')
* Different GPG keyrings (also  hard-coded GPG keyring looks wrong in the first place)

