### PR TITLE
Improved aptly installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ Dependencies
   adding lockfiles.  Fortunately aptly is quick and easy to build.  See
   https://github.com/stb-tester/aptly/tree/lockfile.  To build run:
 
-        $ mkdir -p $GOPATH/src/github.com/stb-tester/aptly
-        $ git clone https://github.com/stb-tester/aptly $GOPATH/src/github.com/stb-tester/aptly
-        $ cd $GOPATH/src/github.com/stb-tester/aptly
+        $ mkdir -p $GOPATH/src/github.com/aptly-dev/aptly
+        $ git clone https://github.com/stb-tester/aptly $GOPATH/src/github.com/aptly-dev/aptly
+        $ cd $GOPATH/src/github.com/aptly-dev/aptly
         $ make install
 
   and add `$GOPATH/bin` to your `$PATH`


### PR DESCRIPTION
With this patch one can actually build the custom version of aptly
by copy-pasting commands from the README.

The source code of aptly must reside in the ``$GOPATH/src/github.com/aptly-dev`` directory (as opposed to ``$GOPATH/src/github.com/stb-tester``). Otherwise import statements

```go
import "github.com/aptly-dev/aptly/utils"
```
will fail and break the build:

```
/tmp/GOPATH/src/github.com/stb-tester/aptly$ make install
go install -v -ldflags "-X main.Version=1.3.0+53+ga64807ef"
main.go:8:2: cannot find package "github.com/aptly-dev/aptly/aptly" in any of:
	/tmp/GOPATH/src/github.com/stb-tester/aptly/vendor/github.com/aptly-dev/aptly/aptly (vendor tree)
	/usr/lib/go-1.13/src/github.com/aptly-dev/aptly/aptly (from $GOROOT)
	/tmp/GOPATH/src/github.com/aptly-dev/aptly/aptly (from $GOPATH)
main.go:9:2: cannot find package "github.com/aptly-dev/aptly/cmd" in any of:
	/tmp/GOPATH/src/github.com/stb-tester/aptly/vendor/github.com/aptly-dev/aptly/cmd (vendor tree)
	/usr/lib/go-1.13/src/github.com/aptly-dev/aptly/cmd (from $GOROOT)
	/tmp/GOPATH/src/github.com/aptly-dev/aptly/cmd (from $GOPATH)
Makefile:37: recipe for target 'install' failed
make: *** [install] Error 1
```