### PR TITLE
bwrap: fix leakage of PATH from host

### DIFF
--- a/apt2ostree/apt.py
+++ b/apt2ostree/apt.py
@@ -281,6 +281,7 @@ dpkg_configure = Rule(
 
         BWRAP="sudo bwrap --bind $$TARGET / --proc /proc --dev /dev
             --tmpfs /tmp --tmpfs /run --setenv LANG C.UTF-8
+            --setenv PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
             --setenv DEBIAN_FRONTEND noninteractive
             $binfmt_misc_support";
         if [ -x $$TARGET/var/lib/dpkg/info/dash.preinst ]; then


### PR DESCRIPTION
Before this commit, the build failed with the following error on my archlinux machine:

    + sudo bwrap --bind _build/tmp/dpkg_configure/deb/images/Packages.lock/configured/co / --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run --setenv LANG C.UTF-8 --setenv DEBIAN_FRONTEND noninteractive dpkg --configure -a
    dpkg: warning: 'sh' not found in PATH or not executable
    dpkg: warning: 'rm' not found in PATH or not executable
    dpkg: warning: 'tar' not found in PATH or not executable
    dpkg: warning: 'ldconfig' not found in PATH or not executable
    dpkg: warning: 'start-stop-daemon' not found in PATH or not executable
    dpkg: error: 5 expected programs not found in PATH or not executable
    Note: root's PATH should usually contain /usr/local/sbin, /usr/sbin and /sbin
    FAILED: _build/ostree/refs/heads/deb/images/Packages.lock/configured 


After some testing, I figured out that the PATH variable from my host system was leaking. Since it is an archlinux machine, the PATH does not contain /bin and /sbin here:

    [lemoer@orange nginx]$ echo $PATH | tr -s : '\n'
    /home/lemoer/.nvm/versions/node/v10.15.1/bin
    /usr/local/bin
    /usr/bin
    /var/lib/snapd/snap/bin
    /usr/bin/site_perl
    /usr/bin/vendor_perl
    /usr/bin/core_perl
    /home/lemoer/bin
    /home/lemoer/.cargo/bin
    /home/lemoer/bin
    /home/lemoer/.cargo/bin
    /home/lemoer/go/bin

With this commit, the PATH is specified explicitly for the bwrap call.